### PR TITLE
Enhance installation script and README to support 'btw' command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ chmod +x install.sh
 The `install.sh` script will:
 - Create necessary directories (`~/.captains-log` and `~/.git-hooks`)
 - Copy `update_log.py` and `commit-msg` hook to the right locations
+- Install the `btw` command globally (accessible from anywhere)
 - Set proper executable permissions
 - Create a default `config.yml` file
 - Configure global git hooks path
@@ -134,9 +135,64 @@ just test-pattern "load_config"
 ```
 
 ## Usage
+
+### Automatic Git Commit Logging
 After setup, every git commit you make will update a daily markdown log file inside the configured log repository/directories.
 
 Logs are grouped by repository name under each project, with a date-based file (e.g., 2025-08-11.md).
+
+### Manual Log Entries with `btw` Command
+The `btw` (By The Way) command allows you to add manual entries to your daily logs from anywhere on your system:
+
+```bash
+btw "Reviewed the new API documentation"
+btw "Had a productive meeting about the architecture"
+btw "Fixed a bug that wasn't committed yet"
+```
+
+#### How `btw` Works:
+- **Smart Project Detection**: Uses the same project detection logic as git commits
+  - If you're in a configured project directory → logs to that project
+  - If not configured → uses the current directory name as project
+- **Consistent Location**: Entries appear in an "other" section at the end of your daily log
+- **Same Infrastructure**: Uses your existing Captain's Log configuration and repositories
+
+#### Examples:
+
+```bash
+# From within your configured project directory
+cd ~/work/my-project
+btw "Completed code review for new feature"
+# → Adds to my-project's daily log under "## other"
+
+# From any directory
+cd ~/Downloads
+btw "Downloaded and reviewed the client requirements"
+# → Adds to Downloads project log under "## other"
+```
+
+#### Installation:
+The `btw` command is automatically installed with the main Captain's Log installation:
+- Accessible globally from any directory
+- Installed to `~/.local/bin/btw` (ensure `~/.local/bin` is in your PATH)
+- No additional setup required after running `install.sh`
+
+#### Log Format:
+Your daily logs will show git commits by repository, followed by manual entries:
+
+```markdown
+# What I did
+
+## repository-name
+- (abc1234) Actual git commit message
+
+## other-repo
+- (def5678) Another git commit
+
+## other
+- Manual entry added with btw command
+- Another manual note
+```
 
 ## Testing
 To test if your installation is working correctly:
@@ -182,3 +238,10 @@ This will test that the hook dispatcher correctly runs pre-commit (if configured
 If you previously used `pre-commit install` in repositories:
 - You can safely leave existing `.git/hooks/` as they won't be used (global `core.hooksPath` takes precedence)
 - Or clean them up with `pre-commit uninstall` in each repo if you prefer
+
+### `btw` command not found
+If the `btw` command is not accessible:
+- Ensure `~/.local/bin` is in your PATH: `echo $PATH | grep ~/.local/bin`
+- Add to your shell profile if missing: `echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc && source ~/.zshrc`
+- Verify the symlink exists: `ls -la ~/.local/bin/btw`
+- Re-run the installation if needed: `./install.sh`

--- a/install.sh
+++ b/install.sh
@@ -13,16 +13,21 @@ mkdir -p "$GIT_HOOKS_DIR"
 
 # Copy script and hook
 echo "Copying update_log.py and commit-msg..."
-cp update_log.py "$CAPT_LOG_DIR/"
+cp src/update_log.py "$CAPT_LOG_DIR/"
 cp commit-msg "$CAPT_LOG_DIR/"
 
 # Copy commit-msg hook to git hooks directory (this is where git will look for it)
 cp commit-msg "$GIT_HOOKS_DIR/commit-msg"
 
+# Copy btw script for global access
+echo "Installing btw command..."
+cp src/btw "$CAPT_LOG_DIR/"
+
 # Make executables
 chmod +x "$CAPT_LOG_DIR/update_log.py"
 chmod +x "$CAPT_LOG_DIR/commit-msg"
 chmod +x "$GIT_HOOKS_DIR/commit-msg"
+chmod +x "$CAPT_LOG_DIR/btw"
 
 # Create basic config.yml if not exist
 if [ ! -f "$CONFIG_FILE" ]; then
@@ -66,5 +71,32 @@ else
   echo "PyYAML is already installed."
 fi
 
+# Setup PATH for btw command
+LOCAL_BIN_DIR="$HOME/.local/bin"
+mkdir -p "$LOCAL_BIN_DIR"
+
+# Create symlink for btw command
+if [ ! -L "$LOCAL_BIN_DIR/btw" ]; then
+  echo "Creating symlink for btw command in $LOCAL_BIN_DIR..."
+  ln -sf "$CAPT_LOG_DIR/btw" "$LOCAL_BIN_DIR/btw"
+else
+  echo "btw command already linked."
+fi
+
+# Check if ~/.local/bin is in PATH
+if [[ ":$PATH:" != *":$LOCAL_BIN_DIR:"* ]]; then
+  echo ""
+  echo "NOTE: $LOCAL_BIN_DIR is not in your PATH."
+  echo "To use the 'btw' command from anywhere, add this line to your shell profile:"
+  echo "  export PATH=\"\$HOME/.local/bin:\$PATH\""
+  echo ""
+  echo "For example, add it to ~/.zshrc (zsh) or ~/.bashrc (bash):"
+  echo "  echo 'export PATH=\"\$HOME/.local/bin:\$PATH\"' >> ~/.zshrc"
+  echo "  source ~/.zshrc"
+  echo ""
+fi
+
 echo "Installation complete! You can now commit as usual."
 echo "Remember to edit your config file at $CONFIG_FILE with your project paths and log repo."
+echo ""
+echo "New feature: Use 'btw \"your note\"' to add manual entries to your daily log!"

--- a/src/btw
+++ b/src/btw
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""
+BTW (By The Way) - Quick log entry tool for Captain's Log
+
+Usage: btw "What I have done"
+
+This adds an entry to today's daily log under a "What I did" section,
+using "other" as the category instead of a repository name.
+"""
+
+import sys
+import os
+from pathlib import Path
+from datetime import date
+import yaml
+
+# Add the src directory to Python path so we can import the main functions
+CAPTAINS_LOG_DIR = Path.home() / ".captains-log"
+SRC_DIR = CAPTAINS_LOG_DIR.parent / "captains-log" / "src"
+if SRC_DIR.exists():
+    sys.path.insert(0, str(SRC_DIR))
+
+# Try to import from installed location first, then from src
+try:
+    from update_log import load_config, get_log_repo_and_path, load_log, commit_and_push, find_project
+    # Import constants for custom save function
+    from update_log import HEADER, FOOTER
+except ImportError:
+    # If not installed, try to import from current directory structure
+    script_dir = Path(__file__).parent.parent.parent
+    src_dir = script_dir / "src"
+    if src_dir.exists():
+        sys.path.insert(0, str(src_dir))
+        from update_log import load_config, get_log_repo_and_path, load_log, commit_and_push, find_project
+        from update_log import HEADER, FOOTER
+    else:
+        print("Error: Cannot find Captain's Log modules. Please ensure Captain's Log is properly installed.")
+        sys.exit(1)
+
+def save_log_with_other_at_end(file_path, repos):
+    """Custom save function that places 'other' section at the end."""
+    try:
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+
+        if not file_path.exists():
+            with file_path.open("w", encoding="utf-8") as f:
+                f.write(HEADER)
+                f.write("\n\n")
+                f.write(FOOTER)
+
+        try:
+            content = file_path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, IOError):
+            # If we can't read the file, start fresh
+            content = HEADER + "\n\n" + FOOTER
+
+        if "# What I did" not in content:
+            content = HEADER + "\n\n" + FOOTER
+        parts = content.split(FOOTER, 1)
+        main_part = parts[0].strip()
+        footer_part = FOOTER
+
+        commit_lines = []
+        
+        # First, add all sections except 'other' in alphabetical order
+        other_entries = None
+        sorted_repos = []
+        for repo_name in sorted(repos.keys(), key=str.lower):
+            if repo_name == "other":
+                other_entries = repos[repo_name]
+            else:
+                sorted_repos.append(repo_name)
+        
+        # Add regular repository sections
+        for repo in sorted_repos:
+            commit_lines.append(f"## {repo}")
+            commit_lines.extend(repos[repo])
+            commit_lines.append("")
+        
+        # Add 'other' section at the end if it exists
+        if other_entries is not None:
+            commit_lines.append("## other")
+            commit_lines.extend(other_entries)
+            commit_lines.append("")
+
+        new_content = HEADER + "\n".join(commit_lines).strip() + "\n\n" + footer_part
+        
+        # Write with atomic operation to avoid corruption
+        temp_file = file_path.with_suffix(file_path.suffix + '.tmp')
+        temp_file.write_text(new_content, encoding="utf-8")
+        temp_file.replace(file_path)
+        
+    except Exception as e:
+        print(f"Error saving log file {file_path}: {e}")
+        raise
+
+def add_manual_entry(entry_text):
+    """Add a manual entry to the daily log under 'other' category."""
+    config = load_config()
+    
+    # Use current working directory to determine project using the same logic as update_log.py
+    cwd = Path.cwd()
+    project = find_project(str(cwd), config)
+    
+    log_repo_path, log_file = get_log_repo_and_path(project, config)
+    
+    # Load existing log
+    repos = load_log(log_file)
+    
+    # Add entry under "other" category
+    category = "other"
+    if category not in repos:
+        repos[category] = []
+    
+    # Format the entry (without commit hash since this is manual)
+    formatted_entry = f"- {entry_text}"
+    
+    # Check if entry already exists to avoid duplicates
+    if formatted_entry not in repos[category]:
+        repos[category].append(formatted_entry)
+        
+        # Save the updated log with 'other' at the end
+        save_log_with_other_at_end(log_file, repos)
+        
+        # Commit and push if we have a log repository
+        if log_repo_path is not None:
+            commit_and_push(log_repo_path, log_file, f"Add manual entry to {project} logs for {date.today().isoformat()}")
+        
+        print(f"Added entry to {project} log: {entry_text}")
+    else:
+        print(f"Entry already exists in {project} log: {entry_text}")
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: btw \"What I have done\"")
+        print("Example: btw \"Reviewed the new API documentation\"")
+        sys.exit(1)
+    
+    # Join all arguments to allow for entries without quotes
+    entry_text = " ".join(sys.argv[1:])
+    
+    if not entry_text.strip():
+        print("Error: Entry text cannot be empty")
+        sys.exit(1)
+    
+    try:
+        add_manual_entry(entry_text)
+    except Exception as e:
+        print(f"Error adding entry: {e}")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Update install.sh to copy 'btw' script for global access and create a symlink in ~/.local/bin.
- Add instructions in README for using the 'btw' command to add manual log entries.
- Include details on how to ensure ~/.local/bin is in PATH for command accessibility.