### PR TITLE
Refactor log handling to remove 'other_at_end' parameter

### DIFF
--- a/src/btw.py
+++ b/src/btw.py
@@ -54,7 +54,7 @@ def add_manual_entry(entry_text: str):
         # Update log data
         log_data.set_repo_entries(category, updated_entries)
         # Save the updated log with 'other' at the end
-        log_manager.save_log(log_info, log_data, other_at_end=True)
+        log_manager.save_log(log_info, log_data)
 
         # Commit and push if we have a git repository
         if log_info.has_git_repo:

--- a/src/entries/entry_processor.py
+++ b/src/entries/entry_processor.py
@@ -70,21 +70,16 @@ class EntryProcessor:
         return updated_entries
 
     def organize_repos_for_output(
-        self, repos: Dict[str, List[str]], other_at_end: bool = False
+        self, repos: Dict[str, List[str]]
     ) -> Dict[str, List[str]]:
         """Organize repositories for output with optional 'other' section placement.
 
         Args:
             repos: Dictionary of repo names to entry lists
-            other_at_end: Whether to place 'other' section at the end
 
         Returns:
             Ordered dictionary ready for output
         """
-        if not other_at_end:
-            # Standard alphabetical sorting
-            return dict(sorted(repos.items(), key=lambda x: x[0].lower()))
-
         # Custom sorting with 'other' at the end
         other_entries = repos.pop("other", None)
         sorted_repos = dict(sorted(repos.items(), key=lambda x: x[0].lower()))

--- a/src/logs/log_manager.py
+++ b/src/logs/log_manager.py
@@ -82,15 +82,12 @@ class LogManager:
         """
         return self.parser.parse_log_file(log_info.file_path)
 
-    def save_log(
-        self, log_info: LogFileInfo, log_data: LogData, other_at_end: bool = False
-    ):
+    def save_log(self, log_info: LogFileInfo, log_data: LogData):
         """Save log data to file.
 
         Args:
             log_info: Log file information
             log_data: Log data to save
-            other_at_end: Whether to place 'other' section at the end
         """
-        writer = LogWriter(other_at_end=other_at_end)
+        writer = LogWriter()
         writer.write_log_file(log_info.file_path, log_data)

--- a/src/logs/log_writer.py
+++ b/src/logs/log_writer.py
@@ -13,13 +13,8 @@ class LogWriter:
     HEADER = "# What I did\n\n"
     FOOTER = "# Whats next\n\n\n# What Broke or Got Weird\n"
 
-    def __init__(self, other_at_end: bool = False):
-        """Initialize the log writer.
-
-        Args:
-            other_at_end: Whether to place 'other' section at the end
-        """
-        self.other_at_end = other_at_end
+    def __init__(self):
+        """Initialize the log writer."""
         self.entry_processor = EntryProcessor()
 
     def write_log_file(self, file_path: Path, log_data: LogData):
@@ -56,7 +51,7 @@ class LogWriter:
 
             # Organize repositories for output
             organized_repos = self.entry_processor.organize_repos_for_output(
-                log_data.repos, self.other_at_end
+                log_data.repos
             )
 
             # Generate content lines

--- a/tests/test_entries.py
+++ b/tests/test_entries.py
@@ -164,7 +164,7 @@ def test_entry_processor_organize_repos_for_output_normal():
     processor = EntryProcessor()
     repos = {"zebra": ["- Entry 1"], "alpha": ["- Entry 2"], "beta": ["- Entry 3"]}
 
-    result = processor.organize_repos_for_output(repos, other_at_end=False)
+    result = processor.organize_repos_for_output(repos)
     expected_order = ["alpha", "beta", "zebra"]
     assert list(result.keys()) == expected_order
 
@@ -178,7 +178,7 @@ def test_entry_processor_organize_repos_for_output_other_at_end():
         "alpha": ["- Entry 2"],
     }
 
-    result = processor.organize_repos_for_output(repos, other_at_end=True)
+    result = processor.organize_repos_for_output(repos)
     expected_order = ["alpha", "zebra", "other"]
     assert list(result.keys()) == expected_order
 
@@ -188,6 +188,6 @@ def test_entry_processor_organize_repos_for_output_no_other():
     processor = EntryProcessor()
     repos = {"zebra": ["- Entry 1"], "alpha": ["- Entry 2"]}
 
-    result = processor.organize_repos_for_output(repos, other_at_end=True)
+    result = processor.organize_repos_for_output(repos)
     expected_order = ["alpha", "zebra"]
     assert list(result.keys()) == expected_order

--- a/tests/test_logs.py
+++ b/tests/test_logs.py
@@ -179,7 +179,7 @@ def test_log_writer_write_log_file_other_at_end(tmp_path):
         }
     )
 
-    writer = LogWriter(other_at_end=True)
+    writer = LogWriter()
     writer.write_log_file(file_path, log_data)
 
     content = file_path.read_text()


### PR DESCRIPTION
- Simplified the log saving and organization process by removing the 'other_at_end' parameter from relevant methods and classes.
- Updated tests to reflect the changes in method signatures and ensure functionality remains intact.