### PR TITLE
Add GitHub Release workflow to automate release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,3 +56,23 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           print-hash: true
+
+  github_release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: publish
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          draft: false
+          prerelease: false
+          generate_release_notes: true


### PR DESCRIPTION
- Introduced a new job in the release workflow to create GitHub releases upon successful publishing.
- Utilized `softprops/action-gh-release@v2` for generating releases with automatic release notes.
- Ensured the workflow runs after the publish job and includes necessary permissions for content writing.