### PR TITLE
Enhance pre-commit integration and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This will:
 - Configure `git config --global core.hooksPath ~/.git-hooks`
 - Create a default `~/.captains-log/config.yml` if it does not exist
 
-After that you can use `btw`, `wtf`, and `captains-log` from anywhere in your shell.
+After that you can use `btw`, `wtf`, `wnext`, and `captains-log` from anywhere in your shell.
 
 See [INSTALLATION.md](INSTALLATION.md) for more detailed installation and configuration examples.
 
@@ -68,7 +68,24 @@ the `git-captains-log` package (and therefore `PyYAML`) via `pipx`, `uv`, or `pi
 in whatever Python environment your Git hooks will use.
 
 ### Pre-commit Integration (Optional)
-If you use [pre-commit](https://pre-commit.com/) in your repositories and want to keep both your global Captain's Log hooks and per-repo pre-commit hooks working together:
+If you use [pre-commit](https://pre-commit.com/) in your repositories and want to keep both your global Captain's Log hooks and per-repo pre-commit hooks working together, you can install global wrapper hooks via the CLI:
+
+```bash
+# After `pipx install git-captains-log` and `captains-log setup`
+captains-log install-precommit-hooks
+```
+
+This will:
+- Install global hook wrappers in `~/.git-hooks` that run pre-commit first (when `.pre-commit-config.yaml` exists)
+- Then run Captain's Log afterwards (via `~/.captains-log/commit-msg`)
+- Configure `git config --global core.hooksPath ~/.git-hooks` (or reuse the existing value if already correct)
+- Work seamlessly with repos that do and do not use pre-commit
+
+**Note:** With pre-commit integration, you don't need to run `pre-commit install` in individual repositories. The global hooks will automatically invoke pre-commit when a repo has `.pre-commit-config.yaml`.
+
+#### Legacy helper script (`install-with-precommit.sh`)
+
+For historical reasons there is also a shell helper script:
 
 ```bash
 # After running install.sh
@@ -76,13 +93,7 @@ chmod +x install-with-precommit.sh
 ./install-with-precommit.sh
 ```
 
-This will:
-- Install global hook wrappers that run pre-commit first (when `.pre-commit-config.yaml` exists)
-- Then run Captain's Log afterwards
-- Preserve your existing `core.hooksPath` configuration
-- Work seamlessly with repos that don't use pre-commit
-
-**Note:** With pre-commit integration, you don't need to run `pre-commit install` in individual repositories. The global hooks will automatically invoke pre-commit when a repo has `.pre-commit-config.yaml`.
+The script performs the same kind of global wrapper installation as `captains-log install-precommit-hooks`, but is kept mainly for backward compatibility.
 
 ### Manual Installation
 If you prefer to install manually (legacy / advanced setup):
@@ -188,7 +199,7 @@ After setup, every git commit you make will update a daily markdown log file ins
 
 Logs are grouped by repository name under each project, with a date-based file (e.g., 2025-08-11.md).
 
-### Manual Log Entries with `btw` and `wtf` Commands
+### Manual Log Entries with `btw`, `wtf`, and `wnext` Commands
 
 #### `btw` Command - Log What You Did
 The `btw` (By The Way) command allows you to add manual entries to your daily logs from anywhere on your system:
@@ -208,6 +219,21 @@ wtf "Database connection timeout after 10 minutes"
 wtf "Tests failing intermittently on CI"
 ```
 
+#### `wnext` Command - Log What’s Next
+
+The `wnext` command lets you quickly add items to the "Whats next" section of your daily logs:
+
+```bash
+# Default: log under the current project subsection
+wnext "Plan sprint backlog refinement"
+
+# Log under a specific project subsection
+wnext --project my-project "Prepare release checklist"
+
+# Log under the generic 'other' subsection
+wnext --other "Remember to update the team wiki"
+```
+
 #### How They Work:
 - **Smart Project Detection**: Uses the same project detection logic as git commits
   - If you're in a configured project directory → logs to that project
@@ -215,6 +241,7 @@ wtf "Tests failing intermittently on CI"
 - **Different Sections**:
   - `btw` entries appear in the "What I did" section under "## other"
   - `wtf` entries appear in the "What Broke or Got Weird" section
+  - `wnext` entries appear in the "Whats next" section, grouped by project subsection or under "## other"
 - **Same Infrastructure**: Uses your existing Captain's Log configuration and repositories
 
 #### Examples:
@@ -235,13 +262,12 @@ btw "Downloaded and reviewed the client requirements"
 ```
 
 #### Installation:
-Both commands are automatically installed with the main Captain's Log installation:
-- Accessible globally from any directory
-- Installed to `~/.local/bin/btw` and `~/.local/bin/wtf` (ensure `~/.local/bin` is in your PATH)
-- No additional setup required after running `install.sh`
+All three commands are automatically installed with the main Captain's Log installation:
+- Accessible globally from any directory (via the `pipx`/`pip` console scripts)
+- When using the legacy `install.sh`, wrapper scripts are installed to `~/.local/bin/btw`, `~/.local/bin/wtf`, and `~/.local/bin/wnext` (ensure `~/.local/bin` is in your PATH)
 
 #### Log Format:
-Your daily logs will show git commits by repository in "What I did", followed by a flat list in "What Broke or Got Weird":
+Your daily logs will show git commits by repository in "What I did", followed by "Whats next" (with optional subsections) and a flat list in "What Broke or Got Weird":
 
 ```markdown
 # What I did
@@ -258,6 +284,11 @@ Your daily logs will show git commits by repository in "What I did", followed by
 
 # Whats next
 
+## my-project
+- Next action logged with wnext
+
+## other
+- General next step logged with wnext --other
 
 # What Broke or Got Weird
 
@@ -292,7 +323,7 @@ This will test that the hook dispatcher correctly runs pre-commit (if configured
 - Verify the `commit-msg` file exists in `~/.git-hooks/` and is executable
 
 ### Pre-commit integration issues
-- Ensure you ran `install.sh` before `install-with-precommit.sh`
+- Ensure you ran `captains-log setup` (or `install.sh` for legacy) before `captains-log install-precommit-hooks` (or `install-with-precommit.sh`)
 - Check that both `commit-msg` and `commit-msg-precommit` exist in `~/.git-hooks/`
 - If pre-commit errors occur, verify you have pre-commit installed: `pip install pre-commit`
 - The integration only runs pre-commit in repos with `.pre-commit-config.yaml`
@@ -310,9 +341,9 @@ If you previously used `pre-commit install` in repositories:
 - You can safely leave existing `.git/hooks/` as they won't be used (global `core.hooksPath` takes precedence)
 - Or clean them up with `pre-commit uninstall` in each repo if you prefer
 
-### `btw` or `wtf` command not found
-If the `btw` or `wtf` commands are not accessible:
+### `btw`, `wtf`, or `wnext` command not found
+If the `btw`, `wtf`, or `wnext` commands are not accessible:
 - Ensure `~/.local/bin` is in your PATH: `echo $PATH | grep ~/.local/bin`
 - Add to your shell profile if missing: `echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.zshrc && source ~/.zshrc`
-- Verify the symlinks exist: `ls -la ~/.local/bin/btw ~/.local/bin/wtf`
-- Re-run the installation if needed: `./install.sh`
+- Verify the symlinks exist (legacy script install): `ls -la ~/.local/bin/btw ~/.local/bin/wtf ~/.local/bin/wnext`
+- Re-run the installation if needed: `./install.sh` or reinstall the package with `pipx install git-captains-log`

--- a/src/_version.py
+++ b/src/_version.py
@@ -28,7 +28,7 @@ version_tuple: VERSION_TUPLE
 commit_id: COMMIT_ID
 __commit_id__: COMMIT_ID
 
-__version__ = version = '0.2.1'
-__version_tuple__ = version_tuple = (0, 2, 1)
+__version__ = version = '0.3.1'
+__version_tuple__ = version_tuple = (0, 3, 1)
 
 __commit_id__ = commit_id = None

--- a/src/cli.py
+++ b/src/cli.py
@@ -131,6 +131,112 @@ projects:
     print()
 
 
+def install_precommit_hooks():
+    """Install global pre-commit wrapper hooks for Captain's Log."""
+    print("=== Installing pre-commit wrapper hooks (global) ===")
+
+    git_hooks_dir = Path.home() / ".git-hooks"
+    git_hooks_dir.mkdir(parents=True, exist_ok=True)
+
+    def write_hook(name: str, content: str) -> None:
+        path = git_hooks_dir / name
+        path.write_text(content, encoding="utf-8")
+        path.chmod(0o755)
+        print(f"  ✓ Installed {name} to {path}")
+
+    pre_commit = """#!/usr/bin/env sh
+
+# Run repo's pre-commit hooks via pre-commit when configured.
+if command -v pre-commit >/dev/null 2>&1 && [ -f ".pre-commit-config.yaml" ]; then
+  exec pre-commit run --hook-stage pre-commit --color always
+fi
+
+exit 0
+"""
+
+    commit_msg_precommit = """#!/usr/bin/env sh
+
+# 1) Run commit-msg stage through pre-commit when configured in this repo
+if command -v pre-commit >/dev/null 2>&1 && [ -f ".pre-commit-config.yaml" ]; then
+  pre-commit run --hook-stage commit-msg --commit-msg-filename "$1" --color always || exit $?
+fi
+
+exit 0
+"""
+
+    captains_log = """#!/usr/bin/env sh
+
+# Captain's Log commit-msg dispatcher
+# Behavior:
+# - If commit-msg-precommit exists: run pre-commit first
+# - Always run Captain's Log hook afterwards
+
+set -eu
+
+HOOKS_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+PRECOMMIT_WRAPPER="$HOOKS_DIR/commit-msg-precommit"
+CAPTAINS_LOG_HOOK="$HOME/.captains-log/commit-msg"
+
+# 1) Run pre-commit wrapper if present
+if [ -x "$PRECOMMIT_WRAPPER" ]; then
+  "$PRECOMMIT_WRAPPER" "$@"
+fi
+
+# 2) Run the original Captain's Log hook
+if [ -x "$CAPTAINS_LOG_HOOK" ]; then
+  exec "$CAPTAINS_LOG_HOOK" "$@"
+fi
+
+exit 0
+"""
+
+    pre_push = """#!/usr/bin/env sh
+
+# Run repo's pre-push hooks via pre-commit when configured.
+if command -v pre-commit >/dev/null 2>&1 && [ -f ".pre-commit-config.yaml" ]; then
+  exec pre-commit run --hook-stage pre-push --color always
+fi
+
+exit 0
+"""
+
+    write_hook("pre-commit", pre_commit)
+    write_hook("commit-msg-precommit", commit_msg_precommit)
+    write_hook("commit-msg", captains_log)
+    write_hook("pre-push", pre_push)
+
+    # Set global git hooks path
+    print("\nConfiguring global Git hooks path...")
+    try:
+        result = subprocess.run(
+            ["git", "config", "--global", "core.hooksPath"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        current_hooks_path = result.stdout.strip()
+
+        if current_hooks_path != str(git_hooks_dir):
+            subprocess.run(
+                ["git", "config", "--global", "core.hooksPath", str(git_hooks_dir)],
+                check=True,
+            )
+            print(f"  ✓ Set global Git hooks path to {git_hooks_dir}")
+            if current_hooks_path:
+                print(f"  ⚠ Previous hooks path was: {current_hooks_path}")
+        else:
+            print("  ✓ Git hooks path already configured")
+    except subprocess.CalledProcessError as e:
+        print(f"  ✗ Error configuring Git hooks: {e}")
+        sys.exit(1)
+
+    print("\nDone. pre-commit wrappers are installed globally.")
+    print("- They run pre-commit in repos with .pre-commit-config.yaml")
+    print(
+        "- The commit-msg wrapper will also run Captain's Log if installed at ~/.captains-log"
+    )
+
+
 def main():
     """Main entry point for the captains-log CLI."""
     if len(sys.argv) < 2:
@@ -138,8 +244,11 @@ def main():
         print(f"Version: {__version__}")
         print()
         print("Usage:")
-        print("  captains-log setup           - Set up Captain's Log")
-        print("  captains-log --version       - Show version")
+        print("  captains-log setup                 - Set up Captain's Log")
+        print(
+            "  captains-log install-precommit-hooks - Install global pre-commit wrappers"
+        )
+        print("  captains-log --version             - Show version")
         print()
         print("After setup, use these commands:")
         print("  btw 'your note'              - Add manual log entries")
@@ -152,9 +261,11 @@ def main():
         print_version()
     elif command == "setup":
         setup()
+    elif command == "install-precommit-hooks":
+        install_precommit_hooks()
     else:
         print(f"Unknown command: {command}")
-        print("Available commands: setup, --version")
+        print("Available commands: setup, install-precommit-hooks, --version")
         sys.exit(1)
 
 

--- a/tests/test_installation.py
+++ b/tests/test_installation.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from src.cli import setup
+from src.cli import install_precommit_hooks, setup
 
 
 @pytest.fixture
@@ -203,6 +203,44 @@ def test_setup_does_not_change_existing_git_hooks_path(
             if len(call[0][0]) > 3 and call[0][0][2] == "core.hooksPath"
         ]
         assert len(set_calls) == 0, "Should not set hooks path if already correct"
+
+
+def test_install_precommit_hooks_installs_wrappers_and_sets_path(mock_home):
+    """Test that install_precommit_hooks installs wrapper hooks and sets core.hooksPath."""
+    with patch("pathlib.Path.home", return_value=mock_home), patch(
+        "subprocess.run"
+    ) as mock_subprocess:
+        git_hooks_dir = mock_home / ".git-hooks"
+
+        call_count = 0
+
+        def mock_run_side_effect(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # First call: git config --global core.hooksPath (get)
+                return MagicMock(stdout="", returncode=0, check=False)
+            elif call_count == 2:
+                # Second call: git config --global core.hooksPath <path> (set)
+                assert args[0][-1] == str(git_hooks_dir), (
+                    "Should set hooks path to ~/.git-hooks"
+                )
+                return MagicMock(returncode=0, check=True)
+            return MagicMock(returncode=0)
+
+        mock_subprocess.side_effect = mock_run_side_effect
+
+        install_precommit_hooks()
+
+        # Verify hooks directory and wrapper scripts exist
+        assert git_hooks_dir.exists()
+        for name in ("pre-commit", "commit-msg-precommit", "commit-msg", "pre-push"):
+            hook_path = git_hooks_dir / name
+            assert hook_path.exists(), f"{name} hook should be created"
+            assert os.access(hook_path, os.X_OK), f"{name} hook should be executable"
+
+        # Verify git config was called to set hooks path
+        assert call_count >= 2, "Should call git config at least twice"
 
 
 def test_setup_handles_missing_commit_msg_hook_gracefully(mock_home, mock_src_module):

--- a/uv.lock
+++ b/uv.lock
@@ -17,6 +17,45 @@ wheels = [
 ]
 
 [[package]]
+name = "build"
+version = "1.2.2.post1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version < '3.9' and os_name == 'nt'" },
+    { name = "importlib-metadata", version = "8.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "packaging", marker = "python_full_version < '3.9'" },
+    { name = "pyproject-hooks", marker = "python_full_version < '3.9'" },
+    { name = "tomli", marker = "python_full_version < '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/46/aeab111f8e06793e4f0e421fcad593d547fb8313b50990f31681ee2fb1ad/build-1.2.2.post1.tar.gz", hash = "sha256:b36993e92ca9375a219c99e606a122ff365a760a2d4bba0caa09bd5278b608b7", size = 46701, upload-time = "2024-10-06T17:22:25.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/c2/80633736cd183ee4a62107413def345f7e6e3c01563dbca1417363cf957e/build-1.2.2.post1-py3-none-any.whl", hash = "sha256:1d61c0887fa860c01971625baae8bdd338e517b836a2f70dd1f7aa3a6b2fc5b5", size = 22950, upload-time = "2024-10-06T17:22:23.299Z" },
+]
+
+[[package]]
+name = "build"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+    "python_full_version == '3.9.*'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version >= '3.9' and os_name == 'nt'" },
+    { name = "importlib-metadata", version = "8.7.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9' and python_full_version < '3.10.2'" },
+    { name = "packaging", marker = "python_full_version >= '3.9'" },
+    { name = "pyproject-hooks", marker = "python_full_version >= '3.9'" },
+    { name = "tomli", marker = "python_full_version >= '3.9' and python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/18/94eaffda7b329535d91f00fe605ab1f1e5cd68b2074d03f255c7d250687d/build-1.4.0.tar.gz", hash = "sha256:f1b91b925aa322be454f8330c6fb48b465da993d1e7e7e6fa35027ec49f3c936", size = 50054, upload-time = "2026-01-08T16:41:47.696Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/0d/84a4380f930db0010168e0aa7b7a8fed9ba1835a8fbb1472bc6d0201d529/build-1.4.0-py3-none-any.whl", hash = "sha256:6a07c1b8eb6f2b311b96fcbdbce5dab5fe637ffda0fd83c9cac622e927501596", size = 24141, upload-time = "2026-01-08T16:41:46.453Z" },
+]
+
+[[package]]
 name = "cachecontrol"
 version = "0.14.2"
 source = { registry = "https://pypi.org/simple" }
@@ -470,7 +509,7 @@ wheels = [
 
 [[package]]
 name = "git-captains-log"
-version = "0.2.1"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },
@@ -492,6 +531,10 @@ dev = [
     { name = "types-pyyaml", version = "6.0.12.20241230", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "types-pyyaml", version = "6.0.12.20250822", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
 ]
+publish = [
+    { name = "build", version = "1.2.2.post1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "build", version = "1.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+]
 test = [
     { name = "pytest", version = "8.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "pytest", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
@@ -512,6 +555,7 @@ dev = [
     { name = "ruff", specifier = ">=0.1.0" },
     { name = "types-pyyaml", specifier = ">=6.0.0" },
 ]
+publish = [{ name = "build", specifier = ">=1.0.0" }]
 test = [
     { name = "pytest", specifier = ">=7.0.0" },
     { name = "pytest-cov", specifier = ">=4.0.0" },
@@ -562,6 +606,37 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
+]
+
+[[package]]
+name = "importlib-metadata"
+version = "8.5.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
+dependencies = [
+    { name = "zipp", version = "3.20.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/12/33e59336dca5be0c398a7482335911a33aa0e20776128f038019f1a95f1b/importlib_metadata-8.5.0.tar.gz", hash = "sha256:71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7", size = 55304, upload-time = "2024-09-11T14:56:08.937Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/d9/a1e041c5e7caa9a05c925f4bdbdfb7f006d1f74996af53467bc394c97be7/importlib_metadata-8.5.0-py3-none-any.whl", hash = "sha256:45e54197d28b7a7f1559e60b95e7c567032b602131fbd588f1497f47880aa68b", size = 26514, upload-time = "2024-09-11T14:56:07.019Z" },
+]
+
+[[package]]
+name = "importlib-metadata"
+version = "8.7.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+    "python_full_version == '3.9.*'",
+]
+dependencies = [
+    { name = "zipp", version = "3.23.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865, upload-time = "2025-12-21T10:00:18.329Z" },
 ]
 
 [[package]]
@@ -1117,6 +1192,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyproject-hooks"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228, upload-time = "2024-09-29T09:24:13.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216, upload-time = "2024-09-29T09:24:11.978Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "8.3.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1496,4 +1580,29 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721, upload-time = "2017-04-05T20:21:34.189Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774, upload-time = "2017-04-05T20:21:32.581Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "3.20.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/54/bf/5c0000c44ebc80123ecbdddba1f5dcd94a5ada602a9c225d84b5aaa55e86/zipp-3.20.2.tar.gz", hash = "sha256:bc9eb26f4506fda01b81bcde0ca78103b6e62f991b381fec825435c836edbc29", size = 24199, upload-time = "2024-09-13T13:44:16.101Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/8b/5ba542fa83c90e09eac972fc9baca7a88e7e7ca4b221a89251954019308b/zipp-3.20.2-py3-none-any.whl", hash = "sha256:a817ac80d6cf4b23bf7f2828b7cabf326f15a001bea8b1f9b49631780ba28350", size = 9200, upload-time = "2024-09-13T13:44:14.38Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "3.23.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+    "python_full_version == '3.9.*'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
 ]


### PR DESCRIPTION
- Added `install-precommit-hooks` command to install global pre-commit wrapper hooks for Captain's Log.
- Updated README.md to include the new `wnext` command for logging "What's next" entries.
- Improved installation instructions and clarified the setup process for pre-commit hooks.